### PR TITLE
Optimized contracts

### DIFF
--- a/packages/distribution-pool/contracts/mock/DistributionPoolMock.sol
+++ b/packages/distribution-pool/contracts/mock/DistributionPoolMock.sol
@@ -8,14 +8,14 @@ import {DistributionPool} from "../DistributionPool.sol";
 contract DistributionPoolMock is DistributionPool {
     function getMemoizedMilestoneAllocation(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public view returns (uint256) {
         return _getMemoizedMilestoneAllocation(_investor, _milestoneId);
     }
 
     function getMemMilestoneAllocation(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public view returns (uint256) {
         return memMilestoneAllocation[_investor][_milestoneId];
     }

--- a/packages/distribution-pool/test/DistributionPool.test.ts
+++ b/packages/distribution-pool/test/DistributionPool.test.ts
@@ -31,17 +31,17 @@ let formated20Percent: BigNumber;
 let formated70Percent: BigNumber;
 
 // Project state values
-let canceledProjectStateValue: BigNumber;
-let beforeFundraiserStateValue: BigNumber;
-let fundraiserOngoingStateValue: BigNumber;
-let failedFundraiserStateValue: BigNumber;
-let fundraiserEndedNoMilestonesOngoingStateValue: BigNumber;
-let milestonesOngoingBeforeLastStateValue: BigNumber;
-let lastMilestoneOngoingStateValue: BigNumber;
-let terminatedByVotingStateValue: BigNumber;
-let terminatedByGelatoStateValue: BigNumber;
-let successfullyEndedStateValue: BigNumber;
-let unknownStateValue: BigNumber;
+let canceledProjectStateValue: number;
+let beforeFundraiserStateValue: number;
+let fundraiserOngoingStateValue: number;
+let failedFundraiserStateValue: number;
+let fundraiserEndedNoMilestonesOngoingStateValue: number;
+let milestonesOngoingBeforeLastStateValue: number;
+let lastMilestoneOngoingStateValue: number;
+let terminatedByVotingStateValue: number;
+let terminatedByGelatoStateValue: number;
+let successfullyEndedStateValue: number;
+let unknownStateValue: number;
 
 const formatPercentage = (percent: BigNumberish): BigNumber => {
     return percentageDivider.mul(percent).div(100);
@@ -55,7 +55,7 @@ const getConstantVariablesFromContract = async () => {
     await createProject();
 
     percentageDivider = await distributionPool.getPercentageDivider();
-    await defineProjectStateByteValues(investmentPool);
+    await defineStateValues(investmentPool);
 };
 
 const createProject = async () => {
@@ -108,7 +108,7 @@ const createProject = async () => {
     await buidl1Token.connect(creator).approve(distributionPool.address, constants.MaxUint256);
 };
 
-const defineProjectStateByteValues = async (investment: InvestmentPoolMockForIntegration) => {
+const defineStateValues = async (investment: InvestmentPoolMockForIntegration) => {
     canceledProjectStateValue = await investment.getCanceledProjectStateValue();
     beforeFundraiserStateValue = await investment.getBeforeFundraiserStateValue();
     fundraiserOngoingStateValue = await investment.getFundraiserOngoingStateValue();

--- a/packages/governance-pool/contracts/mock/GovernancePoolMock.sol
+++ b/packages/governance-pool/contracts/mock/GovernancePoolMock.sol
@@ -11,7 +11,7 @@ import {VotingToken} from "../VotingToken.sol";
 contract GovernancePoolMock is GovernancePool {
     function getMemActiveTokens(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public view returns (uint256) {
         return memActiveTokens[_investor][_milestoneId];
     }

--- a/packages/governance-pool/contracts/mock/InvestmentPoolMockForIntegration.sol
+++ b/packages/governance-pool/contracts/mock/InvestmentPoolMockForIntegration.sol
@@ -7,40 +7,31 @@ import {ISuperfluid, ISuperToken, ISuperApp, ISuperAgreement, SuperAppDefinition
 import {IGovernancePool} from "@buidlone/investment-pool/contracts/interfaces/IGovernancePool.sol";
 import {IDistributionPool} from "@buidlone/investment-pool/contracts/interfaces/IDistributionPool.sol";
 import {IInitializableInvestmentPool, IInvestmentPool} from "@buidlone/investment-pool/contracts/interfaces/IInvestmentPool.sol";
+import {AbstractInvestmentPool, AbstractEmptyInvestmentPool} from "@buidlone/investment-pool/contracts/abstracts/AInvestmentPool.sol";
 
-contract InvestmentPoolMockForIntegration is IInitializableInvestmentPool {
+contract InvestmentPoolMockForIntegration is AbstractInvestmentPool, AbstractEmptyInvestmentPool {
     IGovernancePool public governancePool;
-    uint256 internal currentMilestone = 0;
-    uint256 internal investmentPoolStateValue;
-    uint256 internal constant MILESTONES_ONGOING_BEFORE_LAST_STATE_VALUE = 32;
-    uint256 internal constant LAST_MILESTONE_ONGOING_STATE_VALUE = 64;
-    uint256 internal constant ANY_MILESTONE_ONGOING_STATE_VALUE =
-        MILESTONES_ONGOING_BEFORE_LAST_STATE_VALUE | LAST_MILESTONE_ONGOING_STATE_VALUE;
+    uint16 internal currentMilestone = 0;
+    uint24 internal investmentPoolStateValue;
 
     constructor(IGovernancePool _governancePool) {
         governancePool = _governancePool;
     }
 
-    function initialize(
-        ISuperfluid _host,
-        address payable _gelatoOps,
-        IInvestmentPool.ProjectInfo calldata _projectInfo,
-        IInvestmentPool.VotingTokensMultipliers calldata _multipliers,
-        uint256 _investmentWithdrawFee,
-        MilestoneInterval[] calldata _milestones,
-        IGovernancePool _governancePool,
-        IDistributionPool _distributionPool
-    ) external payable {}
-
-    function mintVotingTokens(uint256 _milestoneId, address _investor, uint256 _amount) public {
+    function mintVotingTokens(uint16 _milestoneId, address _investor, uint256 _amount) public {
         governancePool.mintVotingTokens(_milestoneId, _investor, _amount);
     }
 
-    function burnVotes(uint256 _milestoneId, address _investor) public {
+    function burnVotes(uint16 _milestoneId, address _investor) public {
         governancePool.burnVotes(_milestoneId, _investor);
     }
 
-    function getCurrentMilestoneId() external view returns (uint256) {
+    function getCurrentMilestoneId()
+        external
+        view
+        override(IInvestmentPool, AbstractEmptyInvestmentPool)
+        returns (uint16)
+    {
         return currentMilestone;
     }
 
@@ -48,236 +39,42 @@ contract InvestmentPoolMockForIntegration is IInitializableInvestmentPool {
         currentMilestone += 1;
     }
 
-    function setMilestoneId(uint256 _id) external {
+    function setMilestoneId(uint16 _id) external {
         currentMilestone = _id;
     }
 
-    function setProjectState(uint256 _state) public {
+    function setProjectState(uint24 _state) public {
         investmentPoolStateValue = _state;
     }
 
-    function getProjectStateValue() public view returns (uint256 stateNumber) {
+    function getProjectStateValue()
+        public
+        view
+        override(IInvestmentPool, AbstractEmptyInvestmentPool)
+        returns (uint24 stateNumber)
+    {
         return investmentPoolStateValue;
     }
 
-    function getGovernancePool() public view returns (address) {
+    function getGovernancePool()
+        public
+        view
+        override(IInvestmentPool, AbstractEmptyInvestmentPool)
+        returns (address)
+    {
         return address(governancePool);
     }
 
-    function isStateAnyMilestoneOngoing() external view returns (bool) {
+    function isStateAnyMilestoneOngoing()
+        external
+        view
+        override(IInvestmentPool, AbstractEmptyInvestmentPool)
+        returns (bool)
+    {
         if (investmentPoolStateValue & ANY_MILESTONE_ONGOING_STATE_VALUE == 0) {
             return false;
         } else {
             return true;
         }
     }
-
-    function invest(uint256 _amount, bool _strict) external {}
-
-    function unpledge() external {}
-
-    function refund() external {}
-
-    function cancelBeforeFundraiserStart() external {}
-
-    function cancelDuringMilestones() external {}
-
-    function startFirstFundsStream() external {}
-
-    function advanceToNextMilestone() external {}
-
-    function withdrawEther() external {}
-
-    function isEmergencyTerminated() external view returns (bool) {}
-
-    function isCanceledBeforeFundraiserStart() external view returns (bool) {}
-
-    function isCanceledDuringMilestones() external view returns (bool) {}
-
-    function isSoftCapReached() external view returns (bool) {}
-
-    function isTimeAfterFundraiser() external view returns (bool) {}
-
-    function isTimeBeforeFundraiser() external view returns (bool) {}
-
-    function isTimeWithinFundraiser() external view returns (bool) {}
-
-    function isTimeBetweenFundraiserAndMilestones() external view returns (bool) {}
-
-    function isTimeWithinMilestone(uint _id) external view returns (bool) {}
-
-    function isTimeWithinAnyMilestone() external view returns (bool) {}
-
-    function isTimeWithinLastMilestone() external view returns (bool) {}
-
-    function isFailedFundraiser() external view returns (bool) {}
-
-    function isProjectCompleted() external view returns (bool) {}
-
-    function canTerminateMilestoneStream(uint256 _milestoneId) external view returns (bool) {}
-
-    function canGelatoTerminateMilestoneStream(
-        uint256 _milestoneId
-    ) external view returns (bool) {}
-
-    function getMilestoneSeedAmount(uint256 _milestoneId) external view returns (uint256) {}
-
-    function getMilestoneTotalAllocation(uint _milestoneId) external returns (uint256) {}
-
-    function getInvestorTokensAllocation(
-        address _investor,
-        uint256 _milestoneId
-    ) external view returns (uint256) {}
-
-    function getUsedInvestmentsData(address _investor) external view returns (uint256, uint256) {}
-
-    function getMilestonesWithInvestment(
-        address _investor
-    ) external view returns (uint256[] memory) {}
-
-    function gelatoChecker() external view returns (bool canExec, bytes memory execPayload) {}
-
-    function startGelatoTask() external payable {}
-
-    function gelatoTerminateMilestoneStream(uint256 _milestoneId) external {}
-
-    function getCfaId() external pure returns (bytes32) {}
-
-    function getPercentageDivider() external pure returns (uint256) {}
-
-    function getCanceledProjectStateValue() external pure returns (uint256) {}
-
-    function getBeforeFundraiserStateValue() external pure returns (uint256) {}
-
-    function getFundraiserOngoingStateValue() external pure returns (uint256) {}
-
-    function getFailedFundraiserStateValue() external pure returns (uint256) {}
-
-    function getFundraiserEndedNoMilestonesOngoingStateValue() external pure returns (uint256) {}
-
-    function getMilestonesOngoingBeforeLastStateValue() external pure returns (uint256) {}
-
-    function getLastMilestoneOngoingStateValue() external pure returns (uint256) {}
-
-    function getTerminatedByVotingStateValue() external pure returns (uint256) {}
-
-    function getTerminatedByGelatoStateValue() external pure returns (uint256) {}
-
-    function getSuccessfullyEndedStateValue() external pure returns (uint256) {}
-
-    function getUnknownStateValue() external pure returns (uint256) {}
-
-    function getAnyMilestoneOngoingStateValue() external pure returns (uint256) {}
-
-    function getEthAddress() external pure returns (address) {}
-
-    function getAcceptedToken() external view returns (address) {}
-
-    function getCreator() external view returns (address) {}
-
-    function getGelatoTaskCreated() external view returns (bool) {}
-
-    function getGelatoOps() external view returns (address) {}
-
-    function getGelato() external view returns (address payable) {}
-
-    function getGelatoTask() external view returns (bytes32) {}
-
-    function getSoftCap() external view returns (uint96) {}
-
-    function getHardCap() external view returns (uint96) {}
-
-    function getFundraiserStartTime() external view returns (uint48) {}
-
-    function getFundraiserEndTime() external view returns (uint48) {}
-
-    function getTotalStreamingDuration() external view returns (uint48) {}
-
-    function getTerminationWindow() external view returns (uint48) {}
-
-    function getAutomatedTerminationWindow() external view returns (uint48) {}
-
-    function getEmergencyTerminationTimestamp() external view returns (uint48) {}
-
-    function getTotalInvestedAmount() external view returns (uint256) {}
-
-    function getInvestedAmount(
-        address _investor,
-        uint256 _milestoneId
-    ) external view returns (uint256) {}
-
-    function getMilestonesCount() external view returns (uint256) {}
-
-    function getMilestone(uint256 _milestoneId) external view returns (Milestone memory) {}
-
-    function getInvestmentWithdrawPercentageFee() external view returns (uint256) {}
-
-    function getSoftCapMultiplier() external view returns (uint256) {}
-
-    function getHardCapMultiplier() external view returns (uint256) {}
-
-    function getVotingTokensToMint(uint256 _amount) external view returns (uint256) {}
-
-    function getInvestmentWeight(uint256 _amount) external view returns (uint256) {}
-
-    function getVotingTokensSupplyCap() external view returns (uint256) {}
-
-    function getMaximumWeightDivisor() external view returns (uint256) {}
-
-    function getMilestonesPortionLeft(uint256 _milestoneId) external view returns (uint256) {}
-
-    function getMilestoneDuration(uint256 _milestoneId) external view returns (uint256) {}
-
-    function getFundsUsed() external view returns (uint256) {}
-
-    function beforeAgreementCreated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata ctx
-    ) external view returns (bytes memory cbdata) {}
-
-    function afterAgreementCreated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata cbdata,
-        bytes calldata ctx
-    ) external returns (bytes memory newCtx) {}
-
-    function beforeAgreementTerminated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata ctx
-    ) external view returns (bytes memory cbdata) {}
-
-    function afterAgreementTerminated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata cbdata,
-        bytes calldata ctx
-    ) external returns (bytes memory newCtx) {}
-
-    function beforeAgreementUpdated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata ctx
-    ) external view returns (bytes memory cbdata) {}
-
-    function afterAgreementUpdated(
-        ISuperToken superToken,
-        address agreementClass,
-        bytes32 agreementId,
-        bytes calldata agreementData,
-        bytes calldata cbdata,
-        bytes calldata ctx
-    ) external returns (bytes memory newCtx) {}
 }

--- a/packages/governance-pool/contracts/mock/testing/InvestmentPoolFactoryTestMock.sol
+++ b/packages/governance-pool/contracts/mock/testing/InvestmentPoolFactoryTestMock.sol
@@ -34,11 +34,11 @@ contract InvestmentPoolFactoryTestMock is InvestmentPoolFactory {
         return 15 minutes;
     }
 
-    function getMilestoneMinDuration() public pure override returns (uint256) {
+    function getMilestoneMinDuration() public pure override returns (uint48) {
         return 2 hours;
     }
 
-    function getFundraiserMinDuration() public pure override returns (uint256) {
+    function getFundraiserMinDuration() public pure override returns (uint48) {
         return 1 minutes;
     }
 }

--- a/packages/governance-pool/test/integration/GovernancePool.integration.test.ts
+++ b/packages/governance-pool/test/integration/GovernancePool.integration.test.ts
@@ -61,13 +61,13 @@ let adminRole: string;
 let creationRes: ContractTransaction;
 
 // Percentages (in divider format)
-let percentageDivider: BigNumber = BigNumber.from(0);
-let formated5Percent: BigNumber;
-let formated20Percent: BigNumber;
-let formated70Percent: BigNumber;
+let percentageDivider: number = 0;
+let formated5Percent: number;
+let formated20Percent: number;
+let formated70Percent: number;
 
-const formatPercentage = (percent: BigNumberish): BigNumber => {
-    return percentageDivider.mul(percent).div(100);
+const formatPercentage = (percent: number): number => {
+    return (percentageDivider * percent) / 100;
 };
 
 const dateToSeconds = (date: string): number => {
@@ -389,7 +389,7 @@ describe("Investment Pool integration with Governance Pool and Distribution Pool
 
             await investmentPool.setTimestamp(dateToSeconds("2100/09/15"));
             const softCapMultiplier = await investmentPool.getSoftCapMultiplier();
-            const votesAgainst = softCapMultiplier.mul(investedAmount).mul(2).div(3);
+            const votesAgainst = investedAmount.mul(softCapMultiplier).mul(2).div(3);
 
             await votingToken.connect(investorA).setApprovalForAll(governancePool.address, true);
             await expect(governancePool.connect(investorA).voteAgainst(votesAgainst)).to.emit(

--- a/packages/governance-pool/test/unit/GovernancePool.test.ts
+++ b/packages/governance-pool/test/unit/GovernancePool.test.ts
@@ -19,24 +19,26 @@ let votingToken: VotingToken;
 let governancePool: GovernancePoolMock;
 let investmentPool: InvestmentPoolMockForIntegration;
 
-let votesWithdrawFee: BigNumber;
-let fundraiserOngoingStateValue: BigNumber;
-let anyMilestoneOngoingStateValue: BigNumber;
-let milestonesOngoingBeforeLastStateValue: BigNumber;
-let lastMilestoneOngoingStateValue: BigNumber;
+let votesWithdrawFee: number;
 let governancePoolRole: string;
 
-const defineStateValues = async () => {
-    fundraiserOngoingStateValue = await governancePool.getFundraiserOngoingStateValue();
-    anyMilestoneOngoingStateValue = await governancePool.getAnyMilestoneOngoingStateValue();
-    milestonesOngoingBeforeLastStateValue =
-        await governancePool.getMilestonesOngoingBeforeLastStateValue();
-    lastMilestoneOngoingStateValue = await governancePool.getLastMilestoneOngoingStateValue();
+let fundraiserOngoingStateValue: number;
+let anyMilestoneOngoingStateValue: number;
+let milestonesOngoingBeforeLastStateValue: number;
+let lastMilestoneOngoingStateValue: number;
+
+const defineStateValues = async (ip: InvestmentPoolMockForIntegration) => {
+    fundraiserOngoingStateValue = await ip.getFundraiserOngoingStateValue();
+    anyMilestoneOngoingStateValue = await ip.getAnyMilestoneOngoingStateValue();
+    milestonesOngoingBeforeLastStateValue = await ip.getMilestonesOngoingBeforeLastStateValue();
+    lastMilestoneOngoingStateValue = await ip.getLastMilestoneOngoingStateValue();
 };
 
 const getConstantVariablesFromContract = async () => {
+    await deployContracts();
+
     votesWithdrawFee = await governancePool.getVotesWithdrawPercentageFee();
-    await defineStateValues();
+    await defineStateValues(investmentPool);
 };
 
 const deployContracts = async () => {
@@ -76,7 +78,6 @@ describe("Governance Pool", async () => {
         investmentPoolFactoryAsUser = accounts[5];
 
         // Deploy before defining contract variables
-        await deployContracts();
         await getConstantVariablesFromContract();
     });
 
@@ -628,8 +629,8 @@ describe("Governance Pool", async () => {
                         investorA.address
                     );
 
-                    assert.deepEqual(initialMilestonesIds, [BigNumber.from(0), BigNumber.from(1)]);
-                    assert.deepEqual(milestonesIdsAfterBurn, [BigNumber.from(0)]);
+                    assert.deepEqual(initialMilestonesIds, [0, 1]);
+                    assert.deepEqual(milestonesIdsAfterBurn, [0]);
                 });
 
                 it("[GP][7.1.7] Should update memActiveTokens mapping", async () => {
@@ -1221,10 +1222,7 @@ describe("Governance Pool", async () => {
                         investorA.address
                     );
 
-                    const expectedIds = [
-                        ...priorSenderMilestonesIds,
-                        BigNumber.from(currentMilestoneId),
-                    ];
+                    const expectedIds = [...priorSenderMilestonesIds, currentMilestoneId];
                     assert.deepEqual(endingSenderMilestonesIds, expectedIds);
                 });
 
@@ -1252,10 +1250,7 @@ describe("Governance Pool", async () => {
                     const endingRecipientMilestonesIds =
                         await governancePool.getMilestonesWithVotes(investorB.address);
 
-                    const expectedIds = [
-                        ...priorRecipientMilestonesIds,
-                        BigNumber.from(currentMilestoneId),
-                    ];
+                    const expectedIds = [...priorRecipientMilestonesIds, currentMilestoneId];
                     assert.deepEqual(endingRecipientMilestonesIds, expectedIds);
                 });
 
@@ -1621,10 +1616,7 @@ describe("Governance Pool", async () => {
                         investorA.address
                     );
 
-                    const expectedIds = [
-                        ...priorSenderMilestonesIds,
-                        BigNumber.from(currentMilestoneId),
-                    ];
+                    const expectedIds = [...priorSenderMilestonesIds, currentMilestoneId];
                     assert.deepEqual(endingSenderMilestonesIds, expectedIds);
                 });
 

--- a/packages/investment-pool/contracts/abstracts/AInvestmentPool.sol
+++ b/packages/investment-pool/contracts/abstracts/AInvestmentPool.sol
@@ -1,0 +1,303 @@
+// @ buidl.one 2022
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.14;
+
+import {CFAv1Library} from "@superfluid-finance/ethereum-contracts/contracts/apps/CFAv1Library.sol";
+import {ISuperfluid, ISuperToken, ISuperApp, ISuperAgreement, SuperAppDefinitions} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+import {IGovernancePool} from "../interfaces/IGovernancePool.sol";
+import {IDistributionPool} from "../interfaces/IDistributionPool.sol";
+
+import {IInvestmentPool, IInitializableInvestmentPool} from "../interfaces/IInvestmentPool.sol";
+
+abstract contract AbstractInvestmentPool is IInitializableInvestmentPool {
+    // Divider used for percentage calculations.
+    uint48 internal constant PERCENTAGE_DIVIDER = 10 ** 6;
+
+    /**
+     * @dev Values are used for bitwise operations to determine current project state.
+     * @dev Investment pool can't have multiple states at the same time.
+     */
+    uint24 internal constant CANCELED_PROJECT_STATE_VALUE = 1;
+    uint24 internal constant BEFORE_FUNDRAISER_STATE_VALUE = 2;
+    uint24 internal constant FUNDRAISER_ONGOING_STATE_VALUE = 4;
+    uint24 internal constant FAILED_FUNDRAISER_STATE_VALUE = 8;
+    uint24 internal constant FUNDRAISER_ENDED_NO_MILESTONES_ONGOING_STATE_VALUE = 16;
+    uint24 internal constant MILESTONES_ONGOING_BEFORE_LAST_STATE_VALUE = 32;
+    uint24 internal constant LAST_MILESTONE_ONGOING_STATE_VALUE = 64;
+    uint24 internal constant TERMINATED_BY_VOTING_STATE_VALUE = 128;
+    uint24 internal constant TERMINATED_BY_GELATO_STATE_VALUE = 256;
+    uint24 internal constant SUCCESSFULLY_ENDED_STATE_VALUE = 512;
+    uint24 internal constant UNKNOWN_STATE_VALUE = 1024;
+    uint24 internal constant ANY_MILESTONE_ONGOING_STATE_VALUE =
+        MILESTONES_ONGOING_BEFORE_LAST_STATE_VALUE | LAST_MILESTONE_ONGOING_STATE_VALUE;
+
+    function getPercentageDivider() public pure returns (uint48) {
+        return PERCENTAGE_DIVIDER;
+    }
+
+    function getCanceledProjectStateValue() public pure returns (uint24) {
+        return CANCELED_PROJECT_STATE_VALUE;
+    }
+
+    function getBeforeFundraiserStateValue() public pure returns (uint24) {
+        return BEFORE_FUNDRAISER_STATE_VALUE;
+    }
+
+    function getFundraiserOngoingStateValue() public pure returns (uint24) {
+        return FUNDRAISER_ONGOING_STATE_VALUE;
+    }
+
+    function getFailedFundraiserStateValue() public pure returns (uint24) {
+        return FAILED_FUNDRAISER_STATE_VALUE;
+    }
+
+    function getFundraiserEndedNoMilestonesOngoingStateValue() public pure returns (uint24) {
+        return FUNDRAISER_ENDED_NO_MILESTONES_ONGOING_STATE_VALUE;
+    }
+
+    function getMilestonesOngoingBeforeLastStateValue() public pure returns (uint24) {
+        return MILESTONES_ONGOING_BEFORE_LAST_STATE_VALUE;
+    }
+
+    function getLastMilestoneOngoingStateValue() public pure returns (uint24) {
+        return LAST_MILESTONE_ONGOING_STATE_VALUE;
+    }
+
+    function getTerminatedByVotingStateValue() public pure returns (uint24) {
+        return TERMINATED_BY_VOTING_STATE_VALUE;
+    }
+
+    function getTerminatedByGelatoStateValue() public pure returns (uint24) {
+        return TERMINATED_BY_GELATO_STATE_VALUE;
+    }
+
+    function getSuccessfullyEndedStateValue() public pure returns (uint24) {
+        return SUCCESSFULLY_ENDED_STATE_VALUE;
+    }
+
+    function getUnknownStateValue() public pure returns (uint24) {
+        return UNKNOWN_STATE_VALUE;
+    }
+
+    function getAnyMilestoneOngoingStateValue() public pure returns (uint24) {
+        return ANY_MILESTONE_ONGOING_STATE_VALUE;
+    }
+}
+
+abstract contract AbstractEmptyInvestmentPool is IInitializableInvestmentPool {
+    function initialize(
+        ISuperfluid _host,
+        address payable _gelatoOps,
+        IInvestmentPool.ProjectInfo calldata _projectInfo,
+        IInvestmentPool.VotingTokensMultipliers calldata _multipliers,
+        uint32 _investmentWithdrawFee,
+        IInvestmentPool.MilestoneInterval[] calldata _milestones,
+        IGovernancePool _governancePool,
+        IDistributionPool _distributionPool
+    ) external payable virtual {}
+
+    function invest(uint256 _amount, bool _strict) external virtual {}
+
+    function unpledge() external virtual {}
+
+    function refund() external virtual {}
+
+    function cancelBeforeFundraiserStart() external virtual {}
+
+    function cancelDuringMilestones() external virtual {}
+
+    function startFirstFundsStream() external virtual {}
+
+    function advanceToNextMilestone() external virtual {}
+
+    function withdrawEther() external virtual {}
+
+    function getCurrentMilestoneId() external view virtual returns (uint16) {}
+
+    function isEmergencyTerminated() external view virtual returns (bool) {}
+
+    function isCanceledBeforeFundraiserStart() external view virtual returns (bool) {}
+
+    function isCanceledDuringMilestones() external view virtual returns (bool) {}
+
+    function isSoftCapReached() external view virtual returns (bool) {}
+
+    function isTimeAfterFundraiser() external view virtual returns (bool) {}
+
+    function isTimeBeforeFundraiser() external view virtual returns (bool) {}
+
+    function isTimeWithinFundraiser() external view virtual returns (bool) {}
+
+    function isTimeBetweenFundraiserAndMilestones() external view virtual returns (bool) {}
+
+    function isTimeWithinMilestone(uint16 _id) external view virtual returns (bool) {}
+
+    function isTimeWithinAnyMilestone() external view virtual returns (bool) {}
+
+    function isTimeWithinLastMilestone() external view virtual returns (bool) {}
+
+    function isFailedFundraiser() external view virtual returns (bool) {}
+
+    function isProjectCompleted() external view virtual returns (bool) {}
+
+    function getProjectStateValue() external view virtual returns (uint24 stateNumber) {}
+
+    function canTerminateMilestoneStream(
+        uint16 _milestoneId
+    ) external view virtual returns (bool) {}
+
+    function canGelatoTerminateMilestoneStream(
+        uint16 _milestoneId
+    ) external view virtual returns (bool) {}
+
+    function getMilestoneSeedAmount(uint16 _milestoneId) external view virtual returns (uint256) {}
+
+    function getMilestoneTotalAllocation(uint16 _milestoneId) external virtual returns (uint256) {}
+
+    function getInvestorTokensAllocation(
+        address _investor,
+        uint16 _milestoneId
+    ) external view virtual returns (uint256) {}
+
+    function getFundsUsed() external view virtual returns (uint256) {}
+
+    function getUsedInvestmentsData(
+        address _investor
+    ) external view virtual returns (uint256, uint256) {}
+
+    function isStateAnyMilestoneOngoing() external view virtual returns (bool) {}
+
+    function getMilestonesWithInvestment(
+        address _investor
+    ) external view virtual returns (uint16[] memory) {}
+
+    function gelatoChecker()
+        external
+        view
+        virtual
+        returns (bool canExec, bytes memory execPayload)
+    {}
+
+    function startGelatoTask() external payable virtual {}
+
+    function gelatoTerminateMilestoneStream(uint16 _milestoneId) external virtual {}
+
+    function getCfaId() external pure virtual returns (bytes32) {}
+
+    function getEthAddress() external pure virtual returns (address) {}
+
+    function getAcceptedToken() external view virtual returns (address) {}
+
+    function getCreator() external view virtual returns (address) {}
+
+    function getGelatoTaskCreated() external view virtual returns (bool) {}
+
+    function getGelatoOps() external view virtual returns (address) {}
+
+    function getGelato() external view virtual returns (address payable) {}
+
+    function getGelatoTask() external view virtual returns (bytes32) {}
+
+    function getGovernancePool() external view virtual returns (address) {}
+
+    function getSoftCap() external view virtual returns (uint96) {}
+
+    function getHardCap() external view virtual returns (uint96) {}
+
+    function getFundraiserStartTime() external view virtual returns (uint48) {}
+
+    function getFundraiserEndTime() external view virtual returns (uint48) {}
+
+    function getTotalStreamingDuration() external view virtual returns (uint48) {}
+
+    function getTerminationWindow() external view virtual returns (uint48) {}
+
+    function getAutomatedTerminationWindow() external view virtual returns (uint48) {}
+
+    function getEmergencyTerminationTimestamp() external view virtual returns (uint48) {}
+
+    function getTotalInvestedAmount() external view virtual returns (uint256) {}
+
+    function getInvestedAmount(
+        address _investor,
+        uint16 _milestoneId
+    ) external view virtual returns (uint256) {}
+
+    function getMilestonesCount() external view virtual returns (uint16) {}
+
+    function getMilestone(
+        uint16 _milestoneId
+    ) external view virtual returns (IInvestmentPool.Milestone memory) {}
+
+    function getInvestmentWithdrawPercentageFee() external view virtual returns (uint32) {}
+
+    function getSoftCapMultiplier() external view virtual returns (uint16) {}
+
+    function getHardCapMultiplier() external view virtual returns (uint16) {}
+
+    function getVotingTokensToMint(uint256 _amount) external view virtual returns (uint256) {}
+
+    function getInvestmentWeight(uint256 _amount) external view virtual returns (uint256) {}
+
+    function getVotingTokensSupplyCap() external view virtual returns (uint256) {}
+
+    function getMaximumWeightDivisor() external view virtual returns (uint256) {}
+
+    function getMilestonesPortionLeft(
+        uint16 _milestoneId
+    ) external view virtual returns (uint48) {}
+
+    function getMilestoneDuration(uint16 _milestoneId) external view virtual returns (uint256) {}
+
+    function beforeAgreementCreated(
+        ISuperToken superToken,
+        address agreementClass,
+        bytes32 agreementId,
+        bytes calldata agreementData,
+        bytes calldata ctx
+    ) external view returns (bytes memory cbdata) {}
+
+    function afterAgreementCreated(
+        ISuperToken superToken,
+        address agreementClass,
+        bytes32 agreementId,
+        bytes calldata agreementData,
+        bytes calldata cbdata,
+        bytes calldata ctx
+    ) external returns (bytes memory newCtx) {}
+
+    function beforeAgreementTerminated(
+        ISuperToken superToken,
+        address agreementClass,
+        bytes32 agreementId,
+        bytes calldata agreementData,
+        bytes calldata ctx
+    ) external view returns (bytes memory cbdata) {}
+
+    function afterAgreementTerminated(
+        ISuperToken superToken,
+        address agreementClass,
+        bytes32 agreementId,
+        bytes calldata agreementData,
+        bytes calldata cbdata,
+        bytes calldata ctx
+    ) external returns (bytes memory newCtx) {}
+
+    function beforeAgreementUpdated(
+        ISuperToken superToken,
+        address agreementClass,
+        bytes32 agreementId,
+        bytes calldata agreementData,
+        bytes calldata ctx
+    ) external view returns (bytes memory cbdata) {}
+
+    function afterAgreementUpdated(
+        ISuperToken superToken,
+        address agreementClass,
+        bytes32 agreementId,
+        bytes calldata agreementData,
+        bytes calldata cbdata,
+        bytes calldata ctx
+    ) external returns (bytes memory newCtx) {}
+}

--- a/packages/investment-pool/contracts/interfaces/IDistributionPool.sol
+++ b/packages/investment-pool/contracts/interfaces/IDistributionPool.sol
@@ -10,14 +10,14 @@ interface IDistributionPool {
     function lockTokens() external;
 
     function allocateTokens(
-        uint256 _milestoneId,
+        uint16 _milestoneId,
         address _investor,
         uint256 _investmentWeight,
         uint256 _weightDivisor,
         uint256 _allocationCoefficient
     ) external;
 
-    function removeTokensAllocation(uint256 _milestoneId, address _investor) external;
+    function removeTokensAllocation(uint16 _milestoneId, address _investor) external;
 
     function claimAllocation() external;
 
@@ -29,7 +29,7 @@ interface IDistributionPool {
 
     function getAllocatedAmount(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) external view returns (uint256);
 
     function getAllocationData(address _investor) external view returns (uint256, uint256);
@@ -40,9 +40,9 @@ interface IDistributionPool {
 
     function getMilestonesWithAllocation(
         address _investor
-    ) external view returns (uint256[] memory);
+    ) external view returns (uint16[] memory);
 
-    function getPercentageDivider() external pure returns (uint256);
+    function getPercentageDivider() external view returns (uint48);
 
     function getInvestmentPool() external view returns (address);
 
@@ -53,6 +53,22 @@ interface IDistributionPool {
     function didCreatorLockTokens() external view returns (bool);
 
     function getTotalAllocatedTokens() external view returns (uint256);
+
+    function getCanceledProjectStateValue() external view returns (uint24);
+
+    function getBeforeFundraiserStateValue() external view returns (uint24);
+
+    function getFundraiserOngoingStateValue() external view returns (uint24);
+
+    function getFailedFundraiserStateValue() external view returns (uint24);
+
+    function getFundraiserEndedNoMilestonesOngoingStateValue() external view returns (uint24);
+
+    function getTerminatedByVotingStateValue() external view returns (uint24);
+
+    function getTerminatedByGelatoStateValue() external view returns (uint24);
+
+    function getSuccessfullyEndedStateValue() external view returns (uint24);
 }
 
 interface IInitializableDistributionPool is IDistributionPool {

--- a/packages/investment-pool/contracts/interfaces/IGovernancePool.sol
+++ b/packages/investment-pool/contracts/interfaces/IGovernancePool.sol
@@ -6,13 +6,13 @@ pragma solidity ^0.8.14;
 import {IInvestmentPool} from "./IInvestmentPool.sol";
 
 interface IGovernancePool {
-    function mintVotingTokens(uint256 _milestoneId, address _investor, uint256 _amount) external;
+    function mintVotingTokens(uint16 _milestoneId, address _investor, uint256 _amount) external;
 
     function voteAgainst(uint256 _amount) external;
 
     function retractVotes(uint256 _retractAmount) external;
 
-    function burnVotes(uint256 _milestoneId, address _investor) external;
+    function burnVotes(uint16 _milestoneId, address _investor) external;
 
     function transferVotes(address _recipient, uint256 _amount) external;
 
@@ -24,10 +24,7 @@ interface IGovernancePool {
 
     function thresholdReached(uint256 _investorVotesCount) external view returns (bool);
 
-    function getActiveVotes(
-        uint256 _milestoneId,
-        address _account
-    ) external view returns (uint256);
+    function getActiveVotes(uint16 _milestoneId, address _account) external view returns (uint256);
 
     function getVotingTokensSupply() external view returns (uint256);
 
@@ -39,15 +36,13 @@ interface IGovernancePool {
 
     function getVotesPercentageThreshold() external view returns (uint8);
 
-    function getVotesWithdrawPercentageFee() external view returns (uint256);
+    function getVotesWithdrawPercentageFee() external view returns (uint32);
 
-    function getFundraiserOngoingStateValue() external pure returns (uint256);
+    function getFundraiserOngoingStateValue() external view returns (uint24);
 
-    function getMilestonesOngoingBeforeLastStateValue() external pure returns (uint256);
+    function getMilestonesOngoingBeforeLastStateValue() external view returns (uint24);
 
-    function getLastMilestoneOngoingStateValue() external pure returns (uint256);
-
-    function getAnyMilestoneOngoingStateValue() external pure returns (uint256);
+    function getAnyMilestoneOngoingStateValue() external view returns (uint24);
 
     function getInvestmentPool() external view returns (address);
 
@@ -59,11 +54,11 @@ interface IGovernancePool {
 
     function getTotalLockedAmount() external view returns (uint256);
 
-    function getMilestonesWithVotes(address _investor) external view returns (uint256[] memory);
+    function getMilestonesWithVotes(address _investor) external view returns (uint16[] memory);
 
     function getTokensMinted(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) external view returns (uint256);
 }
 
@@ -72,6 +67,6 @@ interface IInitializableGovernancePool is IGovernancePool {
         address _votingToken,
         IInvestmentPool _investmentPool,
         uint8 _threshold,
-        uint256 _votestWithdrawFee
+        uint32 _votestWithdrawFee
     ) external payable;
 }

--- a/packages/investment-pool/contracts/interfaces/IInvestmentPool.sol
+++ b/packages/investment-pool/contracts/interfaces/IInvestmentPool.sol
@@ -21,8 +21,8 @@ interface IInvestmentPool is ISuperApp {
     }
 
     struct VotingTokensMultipliers {
-        uint256 softCapMultiplier;
-        uint256 hardCapMultiplier;
+        uint16 softCapMultiplier;
+        uint16 hardCapMultiplier;
     }
 
     struct MilestoneInterval {
@@ -33,11 +33,11 @@ interface IInvestmentPool is ISuperApp {
         // Describes the portion of the total funds(all milestones),
         // assigned as a seed portion for this milestone
         // 100% == 10 ** 6
-        uint256 intervalSeedPortion;
+        uint48 intervalSeedPortion;
         // Describes the portion of the total funds(all milestones),
         // assigned as a streaming portion for this milestone
         // 100% == 10 ** 6
-        uint256 intervalStreamingPortion;
+        uint48 intervalStreamingPortion;
     }
 
     struct Milestone {
@@ -50,11 +50,11 @@ interface IInvestmentPool is ISuperApp {
         // Describes the portion of the total funds(all milestones),
         // assigned as a seed portion for this milestone
         // 100% == 10 ** 6
-        uint256 intervalSeedPortion;
+        uint48 intervalSeedPortion;
         // Describes the portion of the total funds(all milestones),
         // assigned as a streaming portion for this milestone
         // 100% == 10 ** 6
-        uint256 intervalStreamingPortion;
+        uint48 intervalStreamingPortion;
         // TODO: More fields here for internal state tracking
     }
 
@@ -74,7 +74,7 @@ interface IInvestmentPool is ISuperApp {
 
     function withdrawEther() external;
 
-    function getCurrentMilestoneId() external view returns (uint256);
+    function getCurrentMilestoneId() external view returns (uint16);
 
     function isEmergencyTerminated() external view returns (bool);
 
@@ -92,7 +92,7 @@ interface IInvestmentPool is ISuperApp {
 
     function isTimeBetweenFundraiserAndMilestones() external view returns (bool);
 
-    function isTimeWithinMilestone(uint _id) external view returns (bool);
+    function isTimeWithinMilestone(uint16 _id) external view returns (bool);
 
     function isTimeWithinAnyMilestone() external view returns (bool);
 
@@ -102,19 +102,19 @@ interface IInvestmentPool is ISuperApp {
 
     function isProjectCompleted() external view returns (bool);
 
-    function getProjectStateValue() external view returns (uint256 stateNumber);
+    function getProjectStateValue() external view returns (uint24 stateNumber);
 
-    function canTerminateMilestoneStream(uint256 _milestoneId) external view returns (bool);
+    function canTerminateMilestoneStream(uint16 _milestoneId) external view returns (bool);
 
-    function canGelatoTerminateMilestoneStream(uint256 _milestoneId) external view returns (bool);
+    function canGelatoTerminateMilestoneStream(uint16 _milestoneId) external view returns (bool);
 
-    function getMilestoneSeedAmount(uint256 _milestoneId) external view returns (uint256);
+    function getMilestoneSeedAmount(uint16 _milestoneId) external view returns (uint256);
 
-    function getMilestoneTotalAllocation(uint _milestoneId) external returns (uint256);
+    function getMilestoneTotalAllocation(uint16 _milestoneId) external returns (uint256);
 
     function getInvestorTokensAllocation(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) external view returns (uint256);
 
     function getFundsUsed() external view returns (uint256);
@@ -125,41 +125,41 @@ interface IInvestmentPool is ISuperApp {
 
     function getMilestonesWithInvestment(
         address _investor
-    ) external view returns (uint256[] memory);
+    ) external view returns (uint16[] memory);
 
     function gelatoChecker() external view returns (bool canExec, bytes memory execPayload);
 
     function startGelatoTask() external payable;
 
-    function gelatoTerminateMilestoneStream(uint256 _milestoneId) external;
+    function gelatoTerminateMilestoneStream(uint16 _milestoneId) external;
 
     function getCfaId() external pure returns (bytes32);
 
-    function getPercentageDivider() external pure returns (uint256);
+    function getPercentageDivider() external pure returns (uint48);
 
-    function getCanceledProjectStateValue() external pure returns (uint256);
+    function getCanceledProjectStateValue() external pure returns (uint24);
 
-    function getBeforeFundraiserStateValue() external pure returns (uint256);
+    function getBeforeFundraiserStateValue() external pure returns (uint24);
 
-    function getFundraiserOngoingStateValue() external pure returns (uint256);
+    function getFundraiserOngoingStateValue() external pure returns (uint24);
 
-    function getFailedFundraiserStateValue() external pure returns (uint256);
+    function getFailedFundraiserStateValue() external pure returns (uint24);
 
-    function getFundraiserEndedNoMilestonesOngoingStateValue() external pure returns (uint256);
+    function getFundraiserEndedNoMilestonesOngoingStateValue() external pure returns (uint24);
 
-    function getMilestonesOngoingBeforeLastStateValue() external pure returns (uint256);
+    function getMilestonesOngoingBeforeLastStateValue() external pure returns (uint24);
 
-    function getLastMilestoneOngoingStateValue() external pure returns (uint256);
+    function getLastMilestoneOngoingStateValue() external pure returns (uint24);
 
-    function getTerminatedByVotingStateValue() external pure returns (uint256);
+    function getTerminatedByVotingStateValue() external pure returns (uint24);
 
-    function getTerminatedByGelatoStateValue() external pure returns (uint256);
+    function getTerminatedByGelatoStateValue() external pure returns (uint24);
 
-    function getSuccessfullyEndedStateValue() external pure returns (uint256);
+    function getSuccessfullyEndedStateValue() external pure returns (uint24);
 
-    function getUnknownStateValue() external pure returns (uint256);
+    function getUnknownStateValue() external pure returns (uint24);
 
-    function getAnyMilestoneOngoingStateValue() external pure returns (uint256);
+    function getAnyMilestoneOngoingStateValue() external pure returns (uint24);
 
     function getEthAddress() external pure returns (address);
 
@@ -197,18 +197,18 @@ interface IInvestmentPool is ISuperApp {
 
     function getInvestedAmount(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) external view returns (uint256);
 
-    function getMilestonesCount() external view returns (uint256);
+    function getMilestonesCount() external view returns (uint16);
 
-    function getMilestone(uint256 _milestoneId) external view returns (Milestone memory);
+    function getMilestone(uint16 _milestoneId) external view returns (Milestone memory);
 
-    function getInvestmentWithdrawPercentageFee() external view returns (uint256);
+    function getInvestmentWithdrawPercentageFee() external view returns (uint32);
 
-    function getSoftCapMultiplier() external view returns (uint256);
+    function getSoftCapMultiplier() external view returns (uint16);
 
-    function getHardCapMultiplier() external view returns (uint256);
+    function getHardCapMultiplier() external view returns (uint16);
 
     function getVotingTokensToMint(uint256 _amount) external view returns (uint256);
 
@@ -218,9 +218,9 @@ interface IInvestmentPool is ISuperApp {
 
     function getMaximumWeightDivisor() external view returns (uint256);
 
-    function getMilestonesPortionLeft(uint256 _milestoneId) external view returns (uint256);
+    function getMilestonesPortionLeft(uint16 _milestoneId) external view returns (uint48);
 
-    function getMilestoneDuration(uint256 _milestoneId) external view returns (uint256);
+    function getMilestoneDuration(uint16 _milestoneId) external view returns (uint256);
 }
 
 interface IInitializableInvestmentPool is IInvestmentPool {
@@ -229,7 +229,7 @@ interface IInitializableInvestmentPool is IInvestmentPool {
         address payable _gelatoOps,
         IInvestmentPool.ProjectInfo calldata _projectInfo,
         IInvestmentPool.VotingTokensMultipliers calldata _multipliers,
-        uint256 _investmentWithdrawFee,
+        uint32 _investmentWithdrawFee,
         MilestoneInterval[] calldata _milestones,
         IGovernancePool _governancePool,
         IDistributionPool _distributionPool

--- a/packages/investment-pool/contracts/interfaces/IInvestmentPoolFactory.sol
+++ b/packages/investment-pool/contracts/interfaces/IInvestmentPoolFactory.sol
@@ -42,27 +42,31 @@ interface IInvestmentPoolFactory {
         IInvestmentPool.MilestoneInterval[] calldata _milestones
     ) external payable returns (address);
 
-    function getMaxMilestoneCount() external pure returns (uint32);
+    function getMaxMilestoneCount() external pure returns (uint16);
 
     function getTerminationWindow() external pure returns (uint48);
 
     function getAutomatedTerminationWindow() external pure returns (uint48);
 
-    function getPercentageDivider() external pure returns (uint256);
+    function getPercentageDivider() external pure returns (uint48);
 
-    function getMilestoneMinDuration() external pure returns (uint256);
+    function getMilestoneMinDuration() external pure returns (uint48);
 
-    function getMilestoneMaxDuration() external pure returns (uint256);
+    function getMilestoneMaxDuration() external pure returns (uint48);
 
-    function getFundraiserMinDuration() external pure returns (uint256);
+    function getFundraiserMinDuration() external pure returns (uint48);
 
-    function getFundraiserMaxDuration() external pure returns (uint256);
+    function getFundraiserMaxDuration() external pure returns (uint48);
 
-    function getInvestmentWithdrawPercentageFee() external pure returns (uint256);
+    function getInvestmentWithdrawPercentageFee() external pure returns (uint32);
 
-    function getSoftCapMultiplier() external pure returns (uint256);
+    function getVotesWithdrawPercentageFee() external pure returns (uint32);
 
-    function getHardCapMultiplier() external pure returns (uint256);
+    function getSoftCapMultiplier() external pure returns (uint16);
+
+    function getHardCapMultiplier() external pure returns (uint16);
+
+    function getMaxProportionalDifference() external pure returns (uint16);
 
     function getGelatoFee() external view returns (uint256);
 

--- a/packages/investment-pool/contracts/mock/DistributionPoolMockForIntegration.sol
+++ b/packages/investment-pool/contracts/mock/DistributionPoolMockForIntegration.sol
@@ -21,14 +21,14 @@ contract DistributionPoolMockForIntegration is IInitializableDistributionPool {
     function lockTokens() external {}
 
     function allocateTokens(
-        uint256 _milestoneId,
+        uint16 _milestoneId,
         address _investor,
         uint256 _investmentWeight,
         uint256 _weightDivisor,
         uint256 _allocationCoefficient
     ) external {}
 
-    function removeTokensAllocation(uint256 _milestoneId, address _investor) external {}
+    function removeTokensAllocation(uint16 _milestoneId, address _investor) external {}
 
     function claimAllocation() external {}
 
@@ -40,7 +40,7 @@ contract DistributionPoolMockForIntegration is IInitializableDistributionPool {
 
     function getAllocatedAmount(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public view returns (uint256) {}
 
     function getAllocationData(address _investor) public view returns (uint256, uint256) {}
@@ -51,9 +51,9 @@ contract DistributionPoolMockForIntegration is IInitializableDistributionPool {
 
     function getMilestonesWithAllocation(
         address _investor
-    ) public view returns (uint256[] memory) {}
+    ) public view returns (uint16[] memory) {}
 
-    function getPercentageDivider() public pure returns (uint256) {}
+    function getPercentageDivider() public view returns (uint48) {}
 
     function getInvestmentPool() public view returns (address) {}
 
@@ -62,4 +62,20 @@ contract DistributionPoolMockForIntegration is IInitializableDistributionPool {
     function getLockedTokens() public view returns (uint256) {}
 
     function getTotalAllocatedTokens() public view returns (uint256) {}
+
+    function getCanceledProjectStateValue() external view returns (uint24) {}
+
+    function getBeforeFundraiserStateValue() external view returns (uint24) {}
+
+    function getFundraiserOngoingStateValue() external view returns (uint24) {}
+
+    function getFailedFundraiserStateValue() external view returns (uint24) {}
+
+    function getFundraiserEndedNoMilestonesOngoingStateValue() external view returns (uint24) {}
+
+    function getTerminatedByVotingStateValue() external view returns (uint24) {}
+
+    function getTerminatedByGelatoStateValue() external view returns (uint24) {}
+
+    function getSuccessfullyEndedStateValue() external view returns (uint24) {}
 }

--- a/packages/investment-pool/contracts/mock/GelatoOpsMock.sol
+++ b/packages/investment-pool/contracts/mock/GelatoOpsMock.sol
@@ -36,7 +36,7 @@ contract GelatoOpsMock is IOps, IOpsProxyFactory {
         return (payable(address(this)));
     }
 
-    function gelatoTerminateMilestoneStream(uint256 _id) public {
+    function gelatoTerminateMilestoneStream(uint16 _id) public {
         executor.gelatoTerminateMilestoneStream(_id);
     }
 

--- a/packages/investment-pool/contracts/mock/GovernancePoolMockForIntegration.sol
+++ b/packages/investment-pool/contracts/mock/GovernancePoolMockForIntegration.sol
@@ -15,16 +15,16 @@ contract GovernancePoolMockForIntegration is IInitializableGovernancePool {
         address _votingToken,
         IInvestmentPool _investmentPool,
         uint8 _threshold,
-        uint256 _votestWithdrawFee
+        uint32 _votestWithdrawFee
     ) external payable {}
 
-    function mintVotingTokens(uint256 _milestoneId, address _investor, uint256 _amount) external {}
+    function mintVotingTokens(uint16 _milestoneId, address _investor, uint256 _amount) external {}
 
     function voteAgainst(uint256 _amount) external {}
 
     function retractVotes(uint256 _retractAmount) external {}
 
-    function burnVotes(uint256 _milestoneId, address _investor) external {}
+    function burnVotes(uint16 _milestoneId, address _investor) external {}
 
     function transferVotes(address _recipient, uint256 _amount) external {}
 
@@ -37,7 +37,7 @@ contract GovernancePoolMockForIntegration is IInitializableGovernancePool {
     function thresholdReached(uint256 _investorVotesCount) external view returns (bool) {}
 
     function getActiveVotes(
-        uint256 _milestoneId,
+        uint16 _milestoneId,
         address _account
     ) external view returns (uint256) {}
 
@@ -51,15 +51,13 @@ contract GovernancePoolMockForIntegration is IInitializableGovernancePool {
 
     function getVotesPercentageThreshold() external view returns (uint8) {}
 
-    function getVotesWithdrawPercentageFee() external view returns (uint256) {}
+    function getVotesWithdrawPercentageFee() external view returns (uint32) {}
 
-    function getFundraiserOngoingStateValue() external pure returns (uint256) {}
+    function getFundraiserOngoingStateValue() external pure returns (uint24) {}
 
-    function getMilestonesOngoingBeforeLastStateValue() external pure returns (uint256) {}
+    function getMilestonesOngoingBeforeLastStateValue() external pure returns (uint24) {}
 
-    function getLastMilestoneOngoingStateValue() external pure returns (uint256) {}
-
-    function getAnyMilestoneOngoingStateValue() external pure returns (uint256) {}
+    function getAnyMilestoneOngoingStateValue() external pure returns (uint24) {}
 
     function getInvestmentPool() external view returns (address) {}
 
@@ -71,10 +69,10 @@ contract GovernancePoolMockForIntegration is IInitializableGovernancePool {
 
     function getTotalLockedAmount() external view returns (uint256) {}
 
-    function getMilestonesWithVotes(address _investor) external view returns (uint256[] memory) {}
+    function getMilestonesWithVotes(address _investor) external view returns (uint16[] memory) {}
 
     function getTokensMinted(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) external view returns (uint256) {}
 }

--- a/packages/investment-pool/contracts/mock/InvestmentPoolMock.sol
+++ b/packages/investment-pool/contracts/mock/InvestmentPoolMock.sol
@@ -19,11 +19,11 @@ contract InvestmentPoolMock is InvestmentPool {
         return timestamp == 0 ? block.timestamp : timestamp;
     }
 
-    function getMemMilestonePortions(uint256 _id) public view returns (uint256) {
+    function getMemMilestonePortions(uint16 _id) public view returns (uint256) {
         return memMilestonePortions[_id];
     }
 
-    function getMemMilestoneInvestments(uint256 _id) public view returns (uint256) {
+    function getMemMilestoneInvestments(uint16 _id) public view returns (uint256) {
         return memMilestoneInvestments[_id];
     }
 
@@ -31,15 +31,15 @@ contract InvestmentPoolMock is InvestmentPool {
         currentMilestone++;
     }
 
-    function setCurrentMilestone(uint256 _milestone) public {
+    function setCurrentMilestone(uint16 _milestone) public {
         currentMilestone = _milestone;
     }
 
-    function terminateMilestoneStreamFinal(uint256 _id) public {
+    function terminateMilestoneStreamFinal(uint16 _id) public {
         _terminateMilestoneStream(_id);
     }
 
-    function claim(uint256 _id) public {
+    function claim(uint16 _id) public {
         _claim(_id);
     }
 
@@ -56,25 +56,25 @@ contract InvestmentPoolMock is InvestmentPool {
     }
 
     function encodeGelatoTerminationWithSelector(
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public pure returns (bytes memory) {
         return abi.encodeWithSelector(this.gelatoTerminateMilestoneStream.selector, _milestoneId);
     }
 
-    function ifNeededUpdateMemInvestmentValue(uint256 _milestoneId) public {
+    function ifNeededUpdateMemInvestmentValue(uint16 _milestoneId) public {
         _updateMemInvestment(_milestoneId);
     }
 
     function getMemoizedInvestorInvestment(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public view returns (uint256) {
         return _getMemoizedInvestorInvestment(_investor, _milestoneId);
     }
 
     function getMemInvestorInvestments(
         address _investor,
-        uint256 _milestoneId
+        uint16 _milestoneId
     ) public view returns (uint256) {
         return memInvestorInvestments[_investor][_milestoneId];
     }

--- a/packages/investment-pool/contracts/utils/Arrays.sol
+++ b/packages/investment-pool/contracts/utils/Arrays.sol
@@ -1,0 +1,45 @@
+// @ buidl.one 2022
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.14;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+library Arrays {
+    /**
+     * @dev Searches a sorted `array` and returns the first index that contains
+     * a value greater or equal to `element`. If no such index exists (i.e. all
+     * values in the array are strictly less than `element`), the array length is
+     * returned. Time complexity O(log n).
+     *
+     * `array` is expected to be sorted in ascending order, and to contain no
+     * repeated elements.
+     */
+    function findUpperBound(uint16[] memory array, uint16 element) internal pure returns (uint16) {
+        if (array.length == 0) {
+            return 0;
+        }
+
+        uint16 low = 0;
+        uint16 high = uint16(array.length);
+
+        while (low < high) {
+            uint16 mid = uint16(Math.average(uint256(low), uint256(high)));
+
+            // Note that mid will always be strictly less than high (i.e. it will be a valid array index)
+            // because Math.average rounds down (it does integer division with truncation).
+            if (array[mid] > element) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        // At this point `low` is the exclusive upper bound. We will return the inclusive upper bound.
+        if (low > 0 && array[low - 1] == element) {
+            return low - 1;
+        } else {
+            return low;
+        }
+    }
+}

--- a/packages/investment-pool/test/InvestmentPoolFactory.test.ts
+++ b/packages/investment-pool/test/InvestmentPoolFactory.test.ts
@@ -21,7 +21,6 @@ const deploySuperToken = require("@superfluid-finance/ethereum-contracts/scripts
 const provider = web3;
 
 // eslint-disable-next-line no-unused-vars
-let fUSDT: InstanceType<typeof fTokenAbi>;
 let fUSDTx: WrapperSuperToken;
 
 let accounts: SignerWithAddress[];
@@ -37,18 +36,19 @@ let governancePoolLogic: GovernancePoolMockForIntegration;
 let distributionPoolLogic: DistributionPoolMockForIntegration;
 let gelatoOpsMock: GelatoOpsMock;
 let votingToken: VotingTokenMock;
-
+let buidl1Token: Buidl1;
 let gelatoFeeAllocation: BigNumber;
-let percentageDivider = BigNumber.from(0);
-let formated5Percent: BigNumber;
-let formated6Percent: BigNumber;
-let formated10Percent: BigNumber;
-let formated40Percent: BigNumber;
-let formated44Percent: BigNumber;
-let formated49Percent: BigNumber;
-let formated51Percent: BigNumber;
-let formated90Percent: BigNumber;
-let formated95Percent: BigNumber;
+
+let percentageDivider: number = 0;
+let formated5Percent: number;
+let formated6Percent: number;
+let formated10Percent: number;
+let formated40Percent: number;
+let formated44Percent: number;
+let formated49Percent: number;
+let formated51Percent: number;
+let formated90Percent: number;
+let formated95Percent: number;
 
 const generateGaplessMilestones = (
     startTimeStamp: number,
@@ -67,8 +67,8 @@ const generateGaplessMilestones = (
         arr.push({
             startDate: prevTimestamp,
             endDate: prevTimestamp + duration,
-            intervalSeedPortion: formated10Percent.div(amount),
-            intervalStreamingPortion: formated90Percent.div(amount),
+            intervalSeedPortion: BigNumber.from(formated10Percent).div(amount),
+            intervalStreamingPortion: BigNumber.from(formated90Percent).div(amount),
         });
         prevTimestamp += duration;
     }
@@ -76,8 +76,8 @@ const generateGaplessMilestones = (
     return arr;
 };
 
-const formatPercentage = (percent: BigNumberish): BigNumber => {
-    return percentageDivider.mul(percent).div(100);
+const formatPercentage = (percent: number): number => {
+    return (percentageDivider * percent) / 100;
 };
 
 const dateToSeconds = (date: string): number => {
@@ -184,7 +184,12 @@ const deploySuperfluidToken = async () => {
     });
 
     fUSDTx = await sf.loadWrapperSuperToken("fUSDTx");
-    fUSDT = new ethers.Contract(fUSDTx.underlyingToken.address, fTokenAbi, superfluidAdmin);
+};
+
+const deployBuidl1Token = async () => {
+    const buidl1TokenDep = await ethers.getContractFactory("Buidl1", creator);
+    buidl1Token = await buidl1TokenDep.deploy();
+    await buidl1Token.deployed();
 };
 
 describe("Investment Pool Factory", async () => {
@@ -197,6 +202,7 @@ describe("Investment Pool Factory", async () => {
         foreignActor = accounts[3];
 
         await deploySuperfluidToken();
+        await deployBuidl1Token();
         await getConstantVariablesFromContract();
     });
 
@@ -428,7 +434,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -469,7 +475,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -547,7 +553,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: constants.AddressZero,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -584,7 +590,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -626,7 +632,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -664,7 +670,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -701,7 +707,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -738,7 +744,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -773,7 +779,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -797,6 +803,7 @@ describe("Investment Pool Factory", async () => {
                 // 30 days
                 const milestoneDuration = 30 * 24 * 60 * 60;
                 const maxMilestones = await investmentPoolFactory.getMaxMilestoneCount();
+
                 const milestones = generateGaplessMilestones(
                     milestoneStartDate,
                     milestoneDuration,
@@ -811,7 +818,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -849,7 +856,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -877,7 +884,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -915,7 +922,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -952,7 +959,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -989,7 +996,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -1028,7 +1035,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -1071,7 +1078,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -1110,7 +1117,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         1, // CLONE-PROXY
@@ -1144,7 +1151,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -1181,7 +1188,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY
@@ -1220,7 +1227,7 @@ describe("Investment Pool Factory", async () => {
                             fundraiserStartAt: fundraiserStartDate,
                             fundraiserEndAt: fundraiserEndDate,
                             acceptedToken: fUSDTx.address,
-                            projectToken: fUSDT.address,
+                            projectToken: buidl1Token.address,
                             tokenRewards: ethers.utils.parseEther("100"),
                         },
                         0, // CLONE-PROXY


### PR DESCRIPTION
- All state variables are only stored on investment pool (not in DP or GP)
- Created abstract contract to store variables needed for all IP mocks
- Moved percentage divider from DP and GP
- Updated uint variables sizes
- Split some functions into smaller parts

State variables and percentage divider is still stored on IPF. We should discuss if we want to pass these variables on project creation to IP since variables are static.